### PR TITLE
fix: hide hp-uiscan

### DIFF
--- a/usr/share/libalpm/hooks/hplip.hook
+++ b/usr/share/libalpm/hooks/hplip.hook
@@ -1,0 +1,10 @@
+[Trigger]
+Type = Package
+Operation = Install
+Operation = Upgrade
+Target = hplip
+
+[Action]
+Description = Fix hp-uiscan desktop file
+When = PostTransaction
+Exec = /usr/share/libalpm/scripts/hplip

--- a/usr/share/libalpm/scripts/hplip
+++ b/usr/share/libalpm/scripts/hplip
@@ -1,3 +1,6 @@
 #!/bin/sh
 
-sudo echo "NoDisplay=true" >> /usr/share/applications/hp-uiscan.desktop
+if [ -z "$(grep NoDisplay=true /usr/share/applications/hp-uiscan.desktop)" ];
+then
+    echo "NoDisplay=true" >> /usr/share/applications/hp-uiscan.desktop
+fi

--- a/usr/share/libalpm/scripts/hplip
+++ b/usr/share/libalpm/scripts/hplip
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+sudo echo "NoDisplay=true" >> /usr/share/applications/hp-uiscan.desktop


### PR DESCRIPTION
## Before
![image](https://github.com/biglinux/biglinux-skel-xfce/assets/16273730/663e3bb0-423a-45e9-a3a9-b18949fc17ff)

![image](https://github.com/biglinux/biglinux-skel-xfce/assets/16273730/7d961535-090c-43da-b07f-e36d33242d8b)

## After
![image](https://github.com/biglinux/biglinux-skel-xfce/assets/16273730/31ae1934-23fb-4b3f-a77f-c263c1fda800)

![image](https://github.com/biglinux/biglinux-skel-xfce/assets/16273730/620da99d-6ff4-4d12-a5be-66559ccf5f10)

## How to test
1. Add hook and script
2. Run `pamac reinstall hplip`
![image](https://github.com/biglinux/biglinux-skel-xfce/assets/16273730/3320b5f8-8633-4274-b2e3-59dc7804db52)
